### PR TITLE
Introduce UidModel subclass of HasProperties

### DIFF
--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -20,6 +20,7 @@ from .base import (
     List,
     Set,
     Tuple,
+    UidModel,
     Union,
 )
 


### PR DESCRIPTION
`UidModel` primarily exists to improve serialization. By adding a uid to all objects, they can be serialized into a flat dictionary that only contains each object once, with all references done by uid (as opposed to the nested structure of `HasProperties` serialization). This also allows recursive self-references to be serialized. This is based on a class written for the OMF library: https://github.com/GMSGDataExchange/omf/blob/v0.9.0/omf/base.py#L12 - see #128 

HasProperties serialization:
<img width="829" alt="screen shot 2017-03-20 at 3 50 40 pm" src="https://cloud.githubusercontent.com/assets/9453731/24123565/a4665826-0d85-11e7-8ff4-f0e9931235ce.png">

UidModel serialization:
<img width="868" alt="screen shot 2017-03-20 at 3 51 09 pm" src="https://cloud.githubusercontent.com/assets/9453731/24123571/abe6eec6-0d85-11e7-9c36-d61e8bec56f0.png">
