### PR TITLE
Allow Instance to initialize from dict with '__class__' specified

### DIFF
--- a/properties/base/instance.py
+++ b/properties/base/instance.py
@@ -99,6 +99,9 @@ class Instance(basic.Property):
             if isinstance(value, self.instance_class):
                 return value
             elif isinstance(value, dict):
+                classname = value.get('__class__', None)
+                if classname == self.instance_class.__name__:
+                    value.pop('__class__')
                 return self.instance_class(**value)
             return self.instance_class(value)
         except (ValueError, KeyError, TypeError):


### PR DESCRIPTION
This is only valid if `__class__` is identical to the `instance_class` name. If more complicated behavior is required, deserialize should be used.

As an example, say you have:

```python
import properties

class Blah(properties.HasProperties):
    a = properties.Integer('')

class HasBlah(properties.HasProperties):
    b = properties.Instance('', Blah)
```

previously this would be fine:

```python
val = HasBlah(b={'a': 5})
```

but this would fail:

```python
val = HasBlah(b={'a': 5, '__class__': 'Blah'})
```

instead requiring:

```python
val = HasBlah.deserialize({'b': {'a': 5, '__class__': 'Blah'}})
```
With this PR, all of the above are valid.