### PR TITLE
Add coerce as an argument to array property

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,7 +122,7 @@ try:
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     pass
-except Exception, e:
+except Exception:
     html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/properties/math.py
+++ b/properties/math.py
@@ -143,9 +143,9 @@ class Array(Property):
             self.error(instance, value)
         if self.coerce:
             value = self.wrapper(value)
-        valid_class = np.ndarray
-        if isinstance(self.wrapper, type):
-            valid_class = self.wrapper
+        valid_class = (
+            self.wrapper if isinstance(self.wrapper, type) else np.ndarray
+        )
         if not isinstance(value, valid_class):
             self.error(instance, value)
         if value.dtype.kind not in (TYPE_MAPPINGS[typ] for typ in self.dtype):

--- a/properties/math.py
+++ b/properties/math.py
@@ -34,17 +34,21 @@ class Array(Property):
       The default value is ('*',).
     * **dtype** - Allowed data type for the array. May be float, int,
       bool, or a tuple containing any of these. The default is (float, int).
+    * **coerce** - If True, the class wrapper function is called on the
+      input to coerce it to the correct type. If False, the input must
+      be the correct type. Default value is True.
     """
 
     class_info = 'a list or numpy array'
 
     @property
     def wrapper(self):
-        """Class used to wrap the value in the validation call.
+        """Function used to wrap the value in the validation call.
 
         For the base Array class, this is a :func:`numpy.array` but
-        subclasses can use other wrappers such as :class:`tuple`,
-        :class:`list` or :class:`vectormath.vector.Vector3`
+        subclasses can use other wrappers such as
+        :class:`vectormath.vector.Vector3` or custom conversion
+        functions.
         """
         return np.array
 
@@ -107,6 +111,17 @@ class Array(Property):
         self._dtype = value
 
     @property
+    def coerce(self):
+        """Coerce sets/lists to tuples or other inputs to length-1 tuples"""
+        return getattr(self, '_coerce', True)
+
+    @coerce.setter
+    def coerce(self, value):
+        if not isinstance(value, bool):
+            raise TypeError('coerce must be a boolean')
+        self._coerce = value
+
+    @property
     def info(self):
         if self.shape is None:
             shape_info = 'any shape'
@@ -126,12 +141,13 @@ class Array(Property):
         """Determine if array is valid based on shape and dtype"""
         if not isinstance(value, (tuple, list, np.ndarray)):
             self.error(instance, value)
-        value = self.wrapper(value)
-        if not isinstance(value, np.ndarray):
-            raise NotImplementedError(
-                'Array validation is only implmented for wrappers that are '
-                'subclasses of numpy.ndarray'
-            )
+        if self.coerce:
+            value = self.wrapper(value)
+        valid_class = np.ndarray
+        if isinstance(self.wrapper, type):
+            valid_class = self.wrapper
+        if not isinstance(value, valid_class):
+            self.error(instance, value)
         if value.dtype.kind not in (TYPE_MAPPINGS[typ] for typ in self.dtype):
             self.error(instance, value, extra='Invalid dtype.')
         if self.shape is None:
@@ -288,6 +304,9 @@ class Vector3(BaseVector):
 
     * **length** - On validation, vectors are scaled to this length. If
       None (the default), vectors are not scaled
+    * **coerce** - If True, the class wrapper function is called on the
+      input to coerce it to the correct type. If False, the input must
+      be the correct type. Default value is True.
     """
 
     class_info = 'a 3D Vector'
@@ -333,6 +352,9 @@ class Vector2(BaseVector):
 
     * **length** - On validation, vectors are scaled to this length. If
       None (the default), vectors are not scaled
+    * **coerce** - If True, the class wrapper function is called on the
+      input to coerce it to the correct type. If False, the input must
+      be the correct type. Default value is True.
     """
 
     class_info = 'a 2D Vector'
@@ -382,6 +404,9 @@ class Vector3Array(BaseVector):
 
     * **length** - On validation, all vectors are scaled to this length. If
       None (the default), vectors are not scaled
+    * **coerce** - If True, the class wrapper function is called on the
+      input to coerce it to the correct type. If False, the input must
+      be the correct type. Default value is True.
     """
 
     class_info = 'a list of Vector3'
@@ -449,6 +474,9 @@ class Vector2Array(BaseVector):
 
     * **length** - On validation, all vectors are scaled to this length. If
       None (the default), vectors are not scaled
+    * **coerce** - If True, the class wrapper function is called on the
+      input to coerce it to the correct type. If False, the input must
+      be the correct type. Default value is True.
     """
 
     class_info = 'a list of Vector2'

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -318,6 +318,29 @@ class TestMath(unittest.TestCase):
         with self.assertRaises(ValueError):
             hv3.vec3 = [[1., 2., 1.], [3., 4., 3.], [5., 6., 5.], [7., 8., 7.]]
 
+    def test_coerce(self):
+
+        class HasNoCoerceArray(properties.HasProperties):
+
+            arr = properties.Array('', coerce=False)
+            vec2 = properties.Vector2('', coerce=False)
+
+            @properties.Array('', coerce=False)
+            def dynamic_arr(self):
+                if getattr(self, '_dynamic_arr', None) is None:
+                    self._dynamic_arr = np.ones(5)
+                return self._dynamic_arr
+
+        no_coerce = HasNoCoerceArray()
+        no_coerce.arr = np.array([1, 2, 3])
+        with self.assertRaises(properties.ValidationError):
+            no_coerce.arr = [1, 2, 3]
+        assert no_coerce.dynamic_arr[0] == 1
+        no_coerce.dynamic_arr[0] = 0
+        assert no_coerce.dynamic_arr[0] == 0
+        no_coerce.vec2 = vmath.Vector2(0., 0.)
+        with self.assertRaises(properties.ValidationError):
+            no_coerce.vec2 = [0., 0.]
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously, `properties.Array` input was always coerced using the `Array.wrapper` attribute. However, this resulted in some funny behaviour with arrays being copied - see #272 

With this PR, there's now an optional `coerce` attribute on the array property. The default is `True` - in that case behaviour is unchanged. If this is False, though, the coerce step will be skipped, and input must start out as the valid type.