### PR TITLE
Support Mixins that use the PropertyMetaclass

### DIFF
--- a/properties/base/base.py
+++ b/properties/base/base.py
@@ -35,7 +35,7 @@ def build_from_bases(bases, classdict, attr, attr_dict):
         # Collect all bases so we ensure overridden items are assigned
         # in the correct order
         for item in reversed(base.__mro__):
-            if item is object or not issubclass(item, HasProperties):
+            if item is object or not isinstance(item, PropertyMetaclass):
                 continue
             if item not in all_bases:
                 all_bases.append(item)

--- a/properties/base/base.py
+++ b/properties/base/base.py
@@ -30,7 +30,7 @@ def build_from_bases(bases, classdict, attr, attr_dict):
     # Go through the bases from furthest to nearest ancestor
     for base in reversed(bases):
         # Only keep the items that are still defined on the bases
-        if base is not object and issubclass(base, HasProperties):
+        if base is not object and isinstance(base, PropertyMetaclass):
             output_keys = output_keys.union(getattr(base, attr))
         # Collect all bases so we ensure overridden items are assigned
         # in the correct order

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -219,7 +219,9 @@ class TestBasic(unittest.TestCase):
 
 
     def test_propertymetaclass_mixin(self):
-        class _StructuredMixinBaseClass(six.with_metaclass(properties.base.PropertyMetaclass, object)):
+        class MixinBaseClass(six.with_metaclass(
+                properties.base.PropertyMetaclass, object
+        )):
             _defaults = dict()
             _REGISTRY = dict()
 
@@ -229,14 +231,14 @@ class TestBasic(unittest.TestCase):
         a = TestA()
         assert a.a is False
 
-        class BMixin(_StructuredMixinBaseClass):
+        class MixinB(MixinBaseClass):
             b = properties.Boolean("test", default=False)
 
-        class C(BMixin, TestA):
+        class TestC(MixinB, TestA):
             pass
 
 
-        c = C()
+        c = TestC()
         assert c.a is False
         assert c.b is False
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -218,6 +218,29 @@ class TestBasic(unittest.TestCase):
         assert AnotherABInheritance._props['b'] is DifferentB._props['b']
 
 
+    def test_propertymetaclass_mixin(self):
+        class _StructuredMixinBaseClass(six.with_metaclass(properties.base.PropertyMetaclass, object)):
+            _defaults = dict()
+            _REGISTRY = dict()
+
+        class TestA(properties.HasProperties):
+            a = properties.Boolean("test", default=False)
+
+        a = TestA()
+        assert a.a is False
+
+        class BMixin(_StructuredMixinBaseClass):
+            b = properties.Boolean("test", default=False)
+
+        class C(BMixin, TestA):
+            pass
+
+
+        c = C()
+        assert c.a is False
+        assert c.b is False
+
+
     def test_bool(self):
 
         for boolean in (properties.Bool, properties.Boolean):


### PR DESCRIPTION
#### Why:

Some Mixins sometimes don't want to be `HasProperties` subclasses (since we need to mix them with other meta classes, eg ABC)

in these cases however we still want the properties defined here to show up in `_props` of base classes.


#### How:

This fix rather than checking that the item class is a `HasProperties` subclass it checks if the item class is an instance of `PropertyMetaclass`. 



